### PR TITLE
Fix calling backend on windows

### DIFF
--- a/src/Compiler/Backend.gren
+++ b/src/Compiler/Backend.gren
@@ -36,7 +36,7 @@ import FileSystem.Path as Path exposing (Path)
 import Compiler.PackageName as PackageName exposing (PackageName)
 import Compiler.Platform as Platform exposing (Platform)
 import SemanticVersion exposing (SemanticVersion)
-import ChildProcess
+import ChildProcess exposing (Shell(..))
 import Json.Encode as Json
 import Dict exposing (Dict)
 import Task exposing (Task)
@@ -272,9 +272,6 @@ run permission options =
                 |> commandEncoder options.interactiveSession options.pathToString
                 |> Json.encode 0
 
-        escapedCommand =
-            "'" ++ commandAsJson ++ "'"
-       
         colorEnvVar =
             if options.useColor then
                 Dict.singleton "FORCE_COLOR" "1"
@@ -284,9 +281,10 @@ run permission options =
     ChildProcess.spawn 
         permission
         (options.pathToString options.compilerPath) 
-        [ escapedCommand ]
+        [ commandAsJson ]
         { ( ChildProcess.defaultSpawnOptions options.onInit options.onComplete )
-            | environmentVariables = 
+            | shell = NoShell
+            , environmentVariables = 
                 ChildProcess.MergeWithEnvironmentVariables colorEnvVar
         }
 


### PR DESCRIPTION
The passed json argument has quote escaping discrepancies between mac/linux and windows without this.

Fixes https://github.com/gren-lang/compiler/issues/276

Not able to fully test this diff because compiler is not updated for 0.5 but I tested a similar change against the latest compatible versions.