### PR TITLE
Add Linux Arm64 as a supported platform.

### DIFF
--- a/src/Compiler/Backend.gren
+++ b/src/Compiler/Backend.gren
@@ -77,6 +77,9 @@ downloadUrl version platform cpuArch =
                 { platform = Node.Linux, cpuArch = Node.X64 } ->
                     Just "gren_linux"
 
+                { platform = Node.Linux, cpuArch = Node.Arm64 } ->
+                    Just "gren_linux_aarch64"
+
                 _ ->
                     Nothing
     in


### PR DESCRIPTION
The github action for the compiler repo now builds this artifact.

Tested on nixos running on an m1 mac, building and running the compiler pointed at this branch locally:

```
❯ uname -sm
Linux aarch64
❯ nix run nixpkgs#gren -- make Main --output=app
Success! Compiled 17 modules.

    Main ───> app

❯ node ./app --version
Compiler not found at /home/justin/.cache/gren/0.6.5/bin/gren. Downloading...
Downloaded
0.6.5
❯ node ./app --version
0.6.5
```